### PR TITLE
Fix getting raw confirmations for raw transaction

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -126,8 +126,10 @@ void TxToJSON(const CTransaction& tx, const uint256 hashBlock, UniValue& entry)
                 entry.push_back(Pair("blocktime", pindex->GetBlockTime()));
             }
             else
+            {
                 entry.push_back(Pair("confirmations", 0));
                 entry.push_back(Pair("rawconfirmations", 0));
+            }
         }
     }
 }


### PR DESCRIPTION
Now there is a duplicated "rawconfirmations" attribute in `getrawtransaction *txid* 1` response
